### PR TITLE
add .travis.yml to .Rbuildignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,2 +1,4 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
+^\.travis\.yml$
+


### PR DESCRIPTION
Need to exclude `.travis.yml` when building the the source package tarball.
