### PR TITLE
Change to a specific import in first function.

### DIFF
--- a/R/download-function.R
+++ b/R/download-function.R
@@ -3,7 +3,7 @@
 #' Grabs data as a dataframe or list of dataframes from a Pangaea data repository URI; see: \url{http://www.pangaea.de/}. Expects the individual data files to be in tab-delimited text format
 #'
 #' @author Naupaka Zimmerman
-#' @import RCurl
+#' @importFrom RCurl getURLContent
 #' @export
 #' @param uri Public internet address of the data
 #' @return dataframe with rows of data, list of dataframes with rows of data if there are multiple related data sets found at the URI


### PR DESCRIPTION
The first function still uses `@import`; think this got missed when we were discussing @naupaka's PR #23.

Change to a specific import from **RCurl**
