### PR TITLE
Fixes to pg getrecord

### DIFF
--- a/R/pg_getrecord.R
+++ b/R/pg_getrecord.R
@@ -5,7 +5,7 @@
 #' @param identifier description
 #' @param transform logical;
 #'
-#' @examples \dontrun{
+#' @examples \donttest{
 #' record <- pg_getrecord(identifier = "oai:pangaea.de:doi:10.1594/PANGAEA.788382")
 #' head(record)
 #' }


### PR DESCRIPTION
Couple of fixes:
- Formal argument `identifier`  had been missed when we converted from `Identifier` to the lowercase form.
- Changed to the `\donttest{}` Rd macro for the examples.
