### PR TITLE
typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ library('pangaear')
 do stuff and things...
 ```
 
-## Contributors (alphebetical)
+## Contributors (alphabetical)
 
 * Scott Chamberlain
 * Andrew MacDonald


### PR DESCRIPTION
Fix a trivial typo in `README.md`
