### PR TITLE
partial fix for long metadata

### DIFF
--- a/R/pg_data.R
+++ b/R/pg_data.R
@@ -116,7 +116,7 @@ is_pangaea <- function(x, doi){
 }
 
 get_meta <- function(x){
-  lns <- readLines(x, n = 300)
+  lns <- readLines(x, n = 1000)
   ln_no <- grep("\\*/", lns) - 1
   use <- lns[2:ln_no]
   structure(list(meta = use), class = "meta")

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -20,7 +20,7 @@ check <- function(x){
 }
 
 read_csv <- function(x){
-  lns <- readLines(x, n = 300)
+  lns <- readLines(x, n = 1000)
   ln_no <- grep("\\*/", lns)
   tmp <- read.csv(x, header = FALSE, sep = "\t", skip = ln_no+1, stringsAsFactors=FALSE)
   nn <- strsplit(lns[ln_no+1], "\t")[[1]]


### PR DESCRIPTION
This command fails
`pg_data(doi = '10.1594/PANGAEA.804606')`
because the meta data is more than 300 lines long so the */ marking the end of the metadata is not found.
I've edited meta_get and read_csv to both look through 1000 lines rather than just 300.

This will obviously fail if the metadata is longer than 1000 rows

I guess a better solution might be to first look at the first 300 rows  and then if the */ is not found, to check the rest of the file.

Richard